### PR TITLE
FORGE-452 : Improve existing security domains 

### DIFF
--- a/repository/src/main/resources/hcm-config/domains/filter-embargo-documents.yaml
+++ b/repository/src/main/resources/hcm-config/domains/filter-embargo-documents.yaml
@@ -1,16 +1,30 @@
 definitions:
   config:
-    /hippo:configuration/hippo:domains/preview-documents/hippo-document/filter-embargo:
+    /hippo:configuration/hippo:domains/preview-documents/hippo-document/hide-embargo-document:
       jcr:primaryType: hipposys:facetrule
       hipposys:equals: false
       hipposys:facet: nodetype
       hipposys:filter: false
       hipposys:type: Name
       hipposys:value: embargo:document
-    /hippo:configuration/hippo:domains/live-documents/hippo-document/filter-embargo:
+    /hippo:configuration/hippo:domains/preview-documents/hippo-document/hide-embargo-handle:
+      jcr:primaryType: hipposys:facetrule
+      hipposys:equals: false
+      hipposys:facet: nodetype
+      hipposys:filter: false
+      hipposys:type: Name
+      hipposys:value: embargo:handle
+    /hippo:configuration/hippo:domains/live-documents/hippo-document/hide-embargo-document:
       jcr:primaryType: hipposys:facetrule
       hipposys:equals: false
       hipposys:facet: nodetype
       hipposys:filter: false
       hipposys:type: Name
       hipposys:value: embargo:document
+    /hippo:configuration/hippo:domains/live-documents/hippo-document/hide-embargo-handle:
+      jcr:primaryType: hipposys:facetrule
+      hipposys:equals: false
+      hipposys:facet: nodetype
+      hipposys:filter: false
+      hipposys:type: Name
+      hipposys:value: embargo:handle


### PR DESCRIPTION
Improve existing security domains for live and preview documents by excluding also the embargo:handle